### PR TITLE
Fixes for compile problems in exten "C" debugPrint routines.

### DIFF
--- a/MapTheThings-Arduino/MapTheThings-Arduino.ino
+++ b/MapTheThings-Arduino/MapTheThings-Arduino.ino
@@ -16,28 +16,28 @@
 
 extern "C"{
   void debugPrint(const char *msg);
-  void debugLog(char *msg, uint16_t value);
-  void debugLogData(char *msg, uint8_t data[], uint16_t len);
+  void debugLog(const char *msg, uint16_t value);
+  void debugLogData(const char *msg, uint8_t data[], uint16_t len);
 }
 
 extern "C" {
-void debugPrint(const char *msg) {
-  Log.Debug(msg);
-  Log.Debug(CR);
+  void debugPrint(const char *msg) {
+    Log.Debug(msg);
+    Log.Debug(CR);
   }
-}
 
-void debugLog(const char *msg, uint16_t value) {
-  Log.Debug("%s %x" CR, msg, value);
-}
-
-void debugLogData(const char *msg, uint8_t data[], uint16_t len) {
-  Log.Debug("%s: ", msg);
-  for(int i=0; i<len; ++i) {
-    Log.Debug("%x", data[i]);
+  void debugLog(const char *msg, uint16_t value) {
+    Log.Debug("%s %x" CR, msg, value);
   }
-  Log.Debug(CR);
-}
+
+  void debugLogData(const char *msg, uint8_t data[], uint16_t len) {
+    Log.Debug("%s: ", msg);
+    for(int i=0; i<len; ++i) {
+      Log.Debug("%x", data[i]);
+    }
+    Log.Debug(CR);
+  }
+} // extern "C".
 
 #define CMD_DISCONNECT 1
 

--- a/MapTheThings-Arduino/MapTheThings-Arduino.ino
+++ b/MapTheThings-Arduino/MapTheThings-Arduino.ino
@@ -20,9 +20,11 @@ extern "C"{
   void debugLogData(char *msg, uint8_t data[], uint16_t len);
 }
 
+extern "C" {
 void debugPrint(const char *msg) {
   Log.Debug(msg);
   Log.Debug(CR);
+  }
 }
 
 void debugLog(const char *msg, uint16_t value) {


### PR DESCRIPTION
This are the changes for issue #4. I found two kinds of problems:

1. compilers inconsistently complain about functions prototyped with extern "C" but then implemented without extern "C".
2. compilers inconsistently complain about a mismatch in const/non-const between prototype and implementation for `debugLog` and `debugLogData`.